### PR TITLE
Change versioning scheme to x.agda-version.y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## v0.2.0 - TBA
+## v0.2.6.2.2 - 2023-11-21
 
-### Fixed 
+### Changed
+
+- Bundle Agda-2.6.2.2
+- Versioning scheme: _x.a.b.c.d.y_ where _a.b.c.d_ is the 4-digit Agda version (2.6.2.2), _x_ is 0 but may be bumped for revolutionary changes to the agda-language-server, and _y_ is for patch releases
+- Builds with `lsp` < 1.5 on GHC 8.10 (LTS 18.28) and 9.0 (LTS 19.33)
+
+## v0.2.1 - 2021-10-25
+
+No changes.
+
+## v0.2.0 - 2021-10-22
+
+### Fixed
 - #2: Allow user to supply command-line options via agda-mode
 
 ## v0.1.4 - 2021-10-04
 
-### Fixed 
+### Fixed
 - Resume sending HighlightingInfos to agda-mode
 
 ## v0.1.3 - 2021-10-04
 
-### Fixed 
+### Fixed
 - Include DLLs in the bundle
 
 ## v0.1.2 - 2021-10-03
 
-### Fixed 
+### Fixed
 - #5: Connection Error
-

--- a/agda-language-server.cabal
+++ b/agda-language-server.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           agda-language-server
-version:        0.2.2.0.2.2.6.2
+version:        0.2.2.6.2
 synopsis:       An implementation of language server protocal (LSP) for Agda 2.
 description:    Please see the README on GitHub at <https://github.com/agda/agda-language-server#readme>
 category:       Development

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                agda-language-server
-version:             0.2.2.0.2.2.6.2
+version:             0.2.2.6.2
 github:              "banacorn/agda-language-server"
 license:             MIT
 author:              "Ting-Gian LUA"


### PR DESCRIPTION
The x.y.z.w.agda-version is too confusing.

Release candidate: https://hackage.haskell.org/package/agda-language-server-0.2.2.6.2/candidate