### PR TITLE
agda 2.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v0.2.6.4.0 - unreleased
+
+### Changed
+- Embed Agda-2.6.4.
+- Builds with `lsp` < 1.7 on GHC 9.2 (LTS 20.26),
+  and with Cabal also on 9.4 and 9.6.
+
+### Added
+- Build flag `Agda-2-6-3` to embed Agda-2.6.3 rather than 2.6.4.
+
+
 ## v0.2.6.3.0 - 2023-11-23
 
 ### Changed
@@ -14,12 +25,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Build flag `Agda-2-6-2-2` to embed Agda-2.6.2.2 rather than 2.6.3.
 
+
 ## v0.2.6.2.2.1 - 2023-11-21
 
 ### Added
 
 - Building with `lsp-1.6`.
   Builds with `lsp` < 1.7 on GHC 8.10 (LTS 18.28), 9.0 (LTS 19.33), and 9.2 (LTS 20.26).
+
 
 ## v0.2.6.2.2 - 2023-11-21
 
@@ -29,24 +42,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Versioning scheme: _x.a.b.c.d.y_ where _a.b.c.d_ is the 4-digit Agda version (2.6.2.2), _x_ is 0 but may be bumped for revolutionary changes to the agda-language-server, and _y_ is for patch releases.
 - Builds with `lsp` < 1.5 on GHC 8.10 (LTS 18.28) and 9.0 (LTS 19.33).
 
+
 ## v0.2.1 - 2021-10-25
 
 No changes.
+
 
 ## v0.2.0 - 2021-10-22
 
 ### Fixed
 - #2: Allow user to supply command-line options via agda-mode
 
+
 ## v0.1.4 - 2021-10-04
 
 ### Fixed
 - Resume sending HighlightingInfos to agda-mode
 
+
 ## v0.1.3 - 2021-10-04
 
 ### Fixed
 - Include DLLs in the bundle
+
 
 ## v0.1.2 - 2021-10-03
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ stack install
 
 ## Versioning
 
-The version is _x.y.z.w.a.b.c.d_ where _x.y.z.w_ is the version of the Agda Language Server and _a.b.c.d_ the version of Agda it embeds.
-It follows the Haskell PVP (package versioning policy).
+The version is _x.a.b.c.d.y_ where _a.b.c.d_ is the 4-digit Agda version (2.6.4.0), _x_ is 0 but may be bumped for revolutionary changes to the agda-language-server, and _y_ is for patch releases.
 
 ## Why make it standalone?
 

--- a/agda-language-server.cabal
+++ b/agda-language-server.cabal
@@ -5,15 +5,15 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           agda-language-server
-version:        0.2.6.3.0
+version:        0.2.6.4.0
 synopsis:       An implementation of language server protocal (LSP) for Agda 2.
 description:    Please see the README on GitHub at <https://github.com/agda/agda-language-server#readme>
 category:       Development
 homepage:       https://github.com/banacorn/agda-language-server#readme
 bug-reports:    https://github.com/banacorn/agda-language-server/issues
 author:         Ting-Gian LUA
-maintainer:     banacorn@gmail.com
-copyright:      2020 Author name here :)
+maintainer:     banacorn@gmail.com, Andreas Abel
+copyright:      2020-23 Ting-Gian LUA, Andreas ABEL
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple
@@ -25,13 +25,19 @@ extra-source-files:
     stack-8.10-Agda-2.6.2.2.yaml
     stack-9.0-Agda-2.6.2.2.yaml
     stack-9.2-Agda-2.6.2.2.yaml
+    stack-9.2-Agda-2.6.3.yaml
 
 source-repository head
   type: git
   location: https://github.com/banacorn/agda-language-server
 
 flag Agda-2-6-2-2
-  description: Embed Agda-2.6.2.2 (rather than 2.6.3)
+  description: Embed Agda-2.6.2.2 (rather than 2.6.4)
+  manual: True
+  default: False
+
+flag Agda-2-6-3
+  description: Embed Agda-2.6.3 (rather than 2.6.4)
   manual: True
   default: False
 
@@ -77,21 +83,29 @@ library
     , base >=4.7 && <5
     , bytestring
     , containers
-    , lsp <1.7
+    , lsp <2
+    , lsp-types <2
     , mtl
     , network
     , network-simple
+    , prettyprinter
     , process
     , stm
     , strict
     , text
   default-language: Haskell2010
-  if flag(Agda-2-6-2-2)
+  if flag(Agda-2-6-2-2) && !flag(Agda-2-6-3)
     build-depends:
         Agda ==2.6.2.2
-  else
+  if !flag(Agda-2-6-2-2) && flag(Agda-2-6-3)
     build-depends:
         Agda ==2.6.3
+  if !flag(Agda-2-6-2-2) && !flag(Agda-2-6-3)
+    build-depends:
+        Agda ==2.6.4
+  if flag(Agda-2-6-2-2) && flag(Agda-2-6-3)
+    build-depends:
+        Agda <0
 
 executable als
   main-is: Main.hs
@@ -111,21 +125,29 @@ executable als
     , base >=4.7 && <5
     , bytestring
     , containers
-    , lsp <1.7
+    , lsp <2
+    , lsp-types <2
     , mtl
     , network
     , network-simple
+    , prettyprinter
     , process
     , stm
     , strict
     , text
   default-language: Haskell2010
-  if flag(Agda-2-6-2-2)
+  if flag(Agda-2-6-2-2) && !flag(Agda-2-6-3)
     build-depends:
         Agda ==2.6.2.2
-  else
+  if !flag(Agda-2-6-2-2) && flag(Agda-2-6-3)
     build-depends:
         Agda ==2.6.3
+  if !flag(Agda-2-6-2-2) && !flag(Agda-2-6-3)
+    build-depends:
+        Agda ==2.6.4
+  if flag(Agda-2-6-2-2) && flag(Agda-2-6-3)
+    build-depends:
+        Agda <0
 
 test-suite als-test
   type: exitcode-stdio-1.0
@@ -172,10 +194,12 @@ test-suite als-test
     , base >=4.7 && <5
     , bytestring
     , containers
-    , lsp <1.7
+    , lsp <2
+    , lsp-types <2
     , mtl
     , network
     , network-simple
+    , prettyprinter
     , process
     , stm
     , strict
@@ -185,9 +209,15 @@ test-suite als-test
     , tasty-quickcheck
     , text
   default-language: Haskell2010
-  if flag(Agda-2-6-2-2)
+  if flag(Agda-2-6-2-2) && !flag(Agda-2-6-3)
     build-depends:
         Agda ==2.6.2.2
-  else
+  if !flag(Agda-2-6-2-2) && flag(Agda-2-6-3)
     build-depends:
         Agda ==2.6.3
+  if !flag(Agda-2-6-2-2) && !flag(Agda-2-6-3)
+    build-depends:
+        Agda ==2.6.4
+  if flag(Agda-2-6-2-2) && flag(Agda-2-6-3)
+    build-depends:
+        Agda <0

--- a/package.yaml
+++ b/package.yaml
@@ -1,10 +1,10 @@
 name:                agda-language-server
-version:             0.2.6.3.0
+version:             0.2.6.4.0
 github:              "banacorn/agda-language-server"
 license:             MIT
 author:              "Ting-Gian LUA"
-maintainer:          "banacorn@gmail.com"
-copyright:           "2020 Author name here :)"
+maintainer:          "banacorn@gmail.com, Andreas Abel"
+copyright:           "2020-23 Ting-Gian LUA, Andreas ABEL"
 
 extra-source-files:
 - README.md
@@ -14,6 +14,7 @@ extra-source-files:
 - stack-8.10-Agda-2.6.2.2.yaml
 - stack-9.0-Agda-2.6.2.2.yaml
 - stack-9.2-Agda-2.6.2.2.yaml
+- stack-9.2-Agda-2.6.3.yaml
 
 # Metadata used when publishing your package
 synopsis:            An implementation of language server protocal (LSP) for Agda 2.
@@ -26,18 +27,27 @@ description:         Please see the README on GitHub at <https://github.com/agda
 
 flags:
   Agda-2-6-2-2:
-    description: Embed Agda-2.6.2.2 (rather than 2.6.3)
+    description: Embed Agda-2.6.2.2 (rather than 2.6.4)
+    manual: true
+    default: false
+  Agda-2-6-3:
+    description: Embed Agda-2.6.3 (rather than 2.6.4)
     manual: true
     default: false
 
 when:
-- condition: flag(Agda-2-6-2-2)
-  then:
-    dependencies:
+- condition: "flag(Agda-2-6-2-2) && !flag(Agda-2-6-3)"
+  dependencies:
     - Agda == 2.6.2.2
-  else:
-    dependencies:
+- condition: "!flag(Agda-2-6-2-2) && flag(Agda-2-6-3)"
+  dependencies:
     - Agda == 2.6.3
+- condition: "!flag(Agda-2-6-2-2) && !flag(Agda-2-6-3)"
+  dependencies:
+    - Agda == 2.6.4
+- condition: "flag(Agda-2-6-2-2) && flag(Agda-2-6-3)"
+  dependencies:
+    - Agda < 0
 
 dependencies:
   - base >= 4.7 && < 5
@@ -45,7 +55,8 @@ dependencies:
   - aeson
   - bytestring
   - containers
-  - lsp < 1.7
+  - lsp-types < 2
+  - lsp < 2
   - mtl
   - network
   - network-simple
@@ -53,6 +64,7 @@ dependencies:
   - stm
   - text
   - process
+  - prettyprinter
 
 default-extensions:
 - LambdaCase

--- a/src/Agda.hs
+++ b/src/Agda.hs
@@ -10,6 +10,8 @@ module Agda
   , getCommandLineOptions
   ) where
 
+import           Prelude                        hiding ( null )
+
 import           Agda.Compiler.Backend          ( parseBackendOptions )
 import           Agda.Compiler.Builtin          ( builtinBackends )
 import           Agda.Convert                   ( fromResponse )
@@ -23,6 +25,9 @@ import           Agda.Interaction.Base          ( Command
                                                 , parseIOTCM
 #endif
                                                 )
+#if MIN_VERSION_Agda(2,6,4)
+import           Agda.Syntax.Common.Pretty      ( render, vcat )
+#endif
 import           Agda.Interaction.InteractionTop
                                                 ( initialiseCommandQueue
                                                 , maybeAbort
@@ -53,6 +58,7 @@ import           Agda.Utils.Impossible          ( CatchImpossible
                                                   )
                                                 , Impossible
                                                 )
+import           Agda.Utils.Null                ( null )
 import           Agda.VersionCommit             ( versionWithCommitInfo )
 import           Control.Exception              ( SomeException
                                                 , catch
@@ -218,7 +224,11 @@ runAgda p = do
     s2s <- prettyTCWarnings' =<< getAllWarningsOfTCErr err
     s1  <- prettyError err
     let ss       = filter (not . null) $ s2s ++ [s1]
+#if MIN_VERSION_Agda(2,6,4)
+    let errorMsg = render $ vcat ss
+#else
     let errorMsg = unlines ss
+#endif
     return (Left errorMsg)
 
   handleImpossible :: Impossible -> TCM (Either String a)

--- a/src/Agda/Convert.hs
+++ b/src/Agda/Convert.hs
@@ -38,7 +38,13 @@ import Agda.Utils.IO.TempFile (writeToTempFile)
 import Agda.Utils.Impossible (__IMPOSSIBLE__)
 import Agda.Utils.Maybe (catMaybes)
 import Agda.Utils.Null (empty)
+#if MIN_VERSION_Agda(2,6,4)
+import Agda.Syntax.Common.Pretty hiding (render)
+-- import Prettyprinter hiding (Doc)
+import qualified Prettyprinter
+#else
 import Agda.Utils.Pretty hiding (render)
+#endif
 import Agda.Utils.RangeMap ( IsBasicRangeMap(toList) )
 import Agda.Utils.String (delimiter)
 import Agda.Utils.Time (CPUTime)
@@ -306,7 +312,12 @@ lispifyGoalSpecificDisplayInfo ii kind = localTCState $
 
         auxSect <- case aux of
           GoalOnly -> return []
+#if MIN_VERSION_Agda(2,6,4)
+          GoalAndHave expr bndry -> do
+            -- TODO: render bndry
+#else
           GoalAndHave expr -> do
+#endif
             rendered <- renderATop expr
             raw <- show <$> prettyATop expr
             return [Labeled rendered (Just raw) Nothing "Have" "special"]
@@ -456,7 +467,11 @@ prettyResponseContext ::
   ResponseContextEntry ->
   TCM [(String, Doc)]
 prettyResponseContext ii (ResponseContextEntry n x (Arg ai expr) letv nis) = withInteractionId ii $ do
+#if MIN_VERSION_Agda(2,6,4)
+  modality <- currentModality
+#else
   modality <- asksTC getModality
+#endif
   do
     let prettyCtxName :: String
         prettyCtxName
@@ -505,7 +520,11 @@ renderResponseContext ::
   ResponseContextEntry ->
   TCM [Block]
 renderResponseContext ii (ResponseContextEntry n x (Arg ai expr) letv nis) = withInteractionId ii $ do
+#if MIN_VERSION_Agda(2,6,4)
+  modality <- currentModality
+#else
   modality <- asksTC getModality
+#endif
   do
     let
         rawCtxName :: String

--- a/src/Agda/Convert.hs
+++ b/src/Agda/Convert.hs
@@ -22,6 +22,9 @@ import Agda.Syntax.Internal (alwaysUnblock)
 import Agda.Syntax.Position (HasRange (getRange), Range, noRange)
 import Agda.Syntax.Scope.Base
 import Agda.TypeChecking.Errors (getAllWarningsOfTCErr, prettyError)
+#if MIN_VERSION_Agda(2,6,3)
+import Agda.TypeChecking.Errors (explainWhyInScope)
+#endif
 import Agda.TypeChecking.Monad hiding (Function)
 import Agda.TypeChecking.Monad.MetaVars (withInteractionId)
 import Agda.TypeChecking.Pretty (prettyTCM)
@@ -259,8 +262,8 @@ fromDisplayInfo = \case
             <+> text (List.intercalate ", " $ words names) $$ nest 2 (align 10 hitDocs)
     return $ IR.DisplayInfoGeneric "Search About" [Unlabeled (Render.text $ show doc) Nothing Nothing]
 #if MIN_VERSION_Agda(2,6,3)
-  Info_WhyInScope (WhyInScopeData q cwd v xs ms) -> do
-    doc <- explainWhyInScope (prettyShow q) cwd v xs ms
+  Info_WhyInScope why -> do
+    doc <- explainWhyInScope why
 #else
   Info_WhyInScope s cwd v xs ms -> do
     doc <- explainWhyInScope s cwd v xs ms
@@ -380,6 +383,7 @@ showInfoError (Info_HighlightingParseError ii) =
 showInfoError (Info_HighlightingScopeCheckError ii) =
   return $ "Highlighting failed to scope check expression in " ++ show ii
 
+#if !MIN_VERSION_Agda(2,6,3)
 explainWhyInScope ::
   String ->
   FilePath ->
@@ -462,6 +466,7 @@ explainWhyInScope s _ v xs ms =
         TCP.<+> "at"
         TCP.<+> TCP.prettyTCM (getRange m)
         TCP.$$ pWhy r w
+#endif
 
 -- | Pretty-prints the context of the given meta-variable.
 prettyResponseContexts ::

--- a/src/Agda/Convert.hs
+++ b/src/Agda/Convert.hs
@@ -9,6 +9,7 @@ import qualified Agda.IR as IR
 import Agda.Interaction.Base
 import Agda.Interaction.BasicOps as B
 import Agda.Interaction.EmacsCommand (Lisp)
+import Agda.Interaction.EmacsTop (showInfoError)
 import Agda.Interaction.Highlighting.Common (chooseHighlightingMethod, toAtoms)
 import Agda.Interaction.Highlighting.Precise (Aspects (..), DefinitionSite (..), HighlightingInfo, TokenBased (..))
 import qualified Agda.Interaction.Highlighting.Range as Highlighting
@@ -350,38 +351,6 @@ lispifyGoalSpecificDisplayInfo ii kind = localTCState $
 -- formatAndCopy = formatPrim True
 
 --------------------------------------------------------------------------------
-
--- | Serializing Info_Error
-showInfoError :: Info_Error -> TCM String
-showInfoError (Info_GenericError err) = do
-  e <- prettyError err
-  w <- prettyTCWarnings' =<< getAllWarningsOfTCErr err
-
-  let errorMsg =
-        if null w
-          then e
-          else delimiter "Error" ++ "\n" ++ e
-  let warningMsg =
-        List.intercalate "\n" $
-          delimiter "Warning(s)" :
-          filter (not . null) w
-  return $
-    if null w
-      then errorMsg
-      else errorMsg ++ "\n\n" ++ warningMsg
-showInfoError (Info_CompilationError warnings) = do
-  s <- prettyTCWarnings warnings
-  return $
-    unlines
-      [ "You need to fix the following errors before you can compile",
-        "the module:",
-        "",
-        s
-      ]
-showInfoError (Info_HighlightingParseError ii) =
-  return $ "Highlighting failed to parse expression in " ++ show ii
-showInfoError (Info_HighlightingScopeCheckError ii) =
-  return $ "Highlighting failed to scope check expression in " ++ show ii
 
 #if !MIN_VERSION_Agda(2,6,3)
 explainWhyInScope ::

--- a/src/Render/Class.hs
+++ b/src/Render/Class.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+
 module Render.Class
   ( Render (..),
     -- RenderTCM (..),
@@ -15,8 +18,13 @@ import qualified Agda.Syntax.Translation.AbstractToConcrete as A
 import qualified Agda.TypeChecking.Monad.Base               as A
 import           Agda.Utils.List1 (List1)
 import           Agda.Utils.List2 (List2)
+#if MIN_VERSION_Agda(2,6,4)
+import           Agda.Syntax.Common.Pretty (Doc)
+import qualified Agda.Syntax.Common.Pretty as Doc
+#else
 import           Agda.Utils.Pretty (Doc)
 import qualified Agda.Utils.Pretty as Doc
+#endif
 
 import           Data.Int (Int32)
 import           GHC.Exts ( IsList(toList) )
@@ -46,7 +54,7 @@ renderP = pure . text . Doc.render . Doc.pretty
 
 -- | like 'prettyA'
 renderA :: (Render c, A.ToConcrete a, A.ConOfAbs a ~ c) => a -> A.TCM Inlines
-renderA x = render <$> A.abstractToConcrete_ x 
+renderA x = render <$> A.abstractToConcrete_ x
 
 -- | like 'prettyATop'
 renderATop :: (Render c, A.ToConcrete a, A.ConOfAbs a ~ c) => a -> A.TCM Inlines

--- a/src/Render/Utils.hs
+++ b/src/Render/Utils.hs
@@ -1,11 +1,16 @@
+{-# LANGUAGE CPP #-}
+
 module Render.Utils where
 
 import Agda.Utils.Time ( CPUTime )
+#if MIN_VERSION_Agda(2,6,4)
+import Agda.Syntax.Common.Pretty (pretty)
+#else
 import Agda.Utils.Pretty (pretty)
+#endif
 
 import Render.Class
 import Render.RichText
-
 
 instance Render CPUTime where
   render = text . show . pretty

--- a/src/Server.hs
+++ b/src/Server.hs
@@ -110,7 +110,9 @@ handlers =
         result <- Handler.onHover uri pos
         responder $ Right result,
       notificationHandler SInitialized $ \_not -> pure (),
-      notificationHandler STextDocumentDidOpen $ \_not -> pure ()
+      notificationHandler STextDocumentDidOpen $ \_not -> pure (),
+      notificationHandler STextDocumentDidSave $ \_not -> pure (),
+      notificationHandler STextDocumentDidChange $ \_not -> pure ()
       -- -- syntax highlighting
       -- , requestHandler STextD_cumentSemanticTokensFull $ \req responder -> do
       --   result <- Handler.onHighlight (req ^. (params . textDocument . uri))

--- a/src/Server.hs
+++ b/src/Server.hs
@@ -1,37 +1,37 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveGeneric #-}
 
 -- entry point of the LSP server
 
 module Server
-  ( run
-  ) where
+  ( run,
+  )
+where
 
 import qualified Agda
-import           Control.Concurrent             ( writeChan )
-import           Control.Monad                  ( void )
-import           Control.Monad.Reader           ( MonadIO(liftIO) )
-import           Data.Aeson                     ( FromJSON
-                                                , ToJSON
-                                                )
-import qualified Data.Aeson                    as JSON
-import           Data.Text                      ( pack )
-import           GHC.IO.IOMode                  ( IOMode(ReadWriteMode) )
-import           Language.LSP.Server     hiding ( Options )
-import           Language.LSP.Types      hiding ( Options(..)
-                                                , TextDocumentSyncClientCapabilities(..)
-                                                )
-import           Monad
-import qualified Network.Simple.TCP            as TCP
-import           Network.Socket                 ( socketToHandle )
+import Control.Concurrent (writeChan)
+import Control.Monad (void)
+import Control.Monad.Reader (MonadIO (liftIO))
+import Data.Aeson
+  ( FromJSON,
+    ToJSON,
+  )
+import qualified Data.Aeson as JSON
+import Data.Text (pack)
+import qualified Data.Text as T
+import GHC.IO.IOMode (IOMode (ReadWriteMode))
+import Language.LSP.Server hiding (Options)
+import qualified Language.LSP.Server as LSP
+import Language.LSP.Types hiding
+  ( Options (..),
+    TextDocumentSyncClientCapabilities (..),
+  )
+import Monad
+import qualified Network.Simple.TCP as TCP
+import Network.Socket (socketToHandle)
+import Options
+import qualified Server.Handler as Handler
+import Switchboard (Switchboard)
 import qualified Switchboard
-import           Switchboard                    ( Switchboard )
-
-import qualified Server.Handler                as Handler
-
-import qualified Language.LSP.Server           as LSP
-import           Options
-
 
 --------------------------------------------------------------------------------
 
@@ -39,76 +39,80 @@ run :: Options -> IO Int
 run options = do
   case optViaTCP options of
     Just port -> do
-      void
-        $ TCP.serve (TCP.Host "127.0.0.1") (show port)
-        $ \(sock, _remoteAddr) -> do
+      void $
+        TCP.serve (TCP.Host "127.0.0.1") (show port) $
+          \(sock, _remoteAddr) -> do
             -- writeChan (envLogChan env) "[Server] connection established"
             handle <- socketToHandle sock ReadWriteMode
-            _      <- runServerWithHandles
+            _ <- runServerWithHandles
 #if MIN_VERSION_lsp(1,5,0)
-                        mempty mempty
+              mempty mempty
 #endif
-                        handle handle (serverDefn options)
+              handle handle (serverDefn options)
             return ()
       -- Switchboard.destroy switchboard
       return 0
     Nothing -> do
       runServer (serverDefn options)
- where
-  serverDefn :: Options -> ServerDefinition Config
-  serverDefn options = ServerDefinition
-    { defaultConfig         = initConfig
-    , onConfigurationChange = \old newRaw -> case JSON.fromJSON newRaw of
-      JSON.Error s -> Left $ pack $ "Cannot parse server configuration: " <> s
-      JSON.Success new -> Right new
-    , doInitialize          = \ctxEnv _req -> do
-                                env <- runLspT ctxEnv (createInitEnv options)
-                                switchboard <- Switchboard.new env
-                                Switchboard.setupLanguageContextEnv switchboard ctxEnv
-                                pure $ Right (ctxEnv, env)
-    , staticHandlers        = handlers
-    , interpretHandler      = \(ctxEnv, env) ->
-                                Iso (runLspT ctxEnv . runServerM env) liftIO
-    , options               = lspOptions
-    }
+  where
+    serverDefn :: Options -> ServerDefinition Config
+    serverDefn options =
+      ServerDefinition
+        { defaultConfig = initConfig,
+          onConfigurationChange = \old newRaw -> case JSON.fromJSON newRaw of
+            JSON.Error s -> Left $ pack $ "Cannot parse server configuration: " <> s
+            JSON.Success new -> Right new,
+          doInitialize = \ctxEnv _req -> do
+            env <- runLspT ctxEnv (createInitEnv options)
+            switchboard <- Switchboard.new env
+            Switchboard.setupLanguageContextEnv switchboard ctxEnv
+            pure $ Right (ctxEnv, env),
+          staticHandlers = handlers,
+          interpretHandler = \(ctxEnv, env) ->
+            Iso (runLspT ctxEnv . runServerM env) liftIO,
+          options = lspOptions
+        }
 
-  lspOptions :: LSP.Options
-  lspOptions = defaultOptions { textDocumentSync = Just syncOptions }
+    lspOptions :: LSP.Options
+    lspOptions = defaultOptions {textDocumentSync = Just syncOptions}
 
-  -- these `TextDocumentSyncOptions` are essential for receiving notifications from the client
-  syncOptions :: TextDocumentSyncOptions
-  syncOptions = TextDocumentSyncOptions { _openClose = Just True -- receive open and close notifications from the client
-                                        , _change = Just changeOptions -- receive change notifications from the client
-                                        , _willSave = Just False -- receive willSave notifications from the client
-                                        , _willSaveWaitUntil = Just False -- receive willSave notifications from the client
-                                        , _save = Just $ InR saveOptions
-                                        }
+    -- these `TextDocumentSyncOptions` are essential for receiving notifications from the client
+    syncOptions :: TextDocumentSyncOptions
+    syncOptions =
+      TextDocumentSyncOptions
+        { _openClose = Just True, -- receive open and close notifications from the client
+          _change = Just changeOptions, -- receive change notifications from the client
+          _willSave = Just False, -- receive willSave notifications from the client
+          _willSaveWaitUntil = Just False, -- receive willSave notifications from the client
+          _save = Just $ InR saveOptions
+        }
 
-  changeOptions :: TextDocumentSyncKind
-  changeOptions = TdSyncIncremental
+    changeOptions :: TextDocumentSyncKind
+    changeOptions = TdSyncIncremental
 
-  -- includes the document content on save, so that we don't have to read it from the disk
-  saveOptions :: SaveOptions
-  saveOptions = SaveOptions (Just True)
+    -- includes the document content on save, so that we don't have to read it from the disk
+    saveOptions :: SaveOptions
+    saveOptions = SaveOptions (Just True)
 
 -- handlers of the LSP server
 handlers :: Handlers (ServerM (LspM Config))
-handlers = mconcat
-  [ -- custom methods, not part of LSP
-    requestHandler (SCustomMethod "agda") $ \req responder -> do
-    let RequestMessage _ _i _ params = req
-    response <- Agda.sendCommand params
-    responder $ Right response
-  ,
-        -- hover provider
-    requestHandler STextDocumentHover $ \req responder -> do
-    let
-      RequestMessage _ _ _ (HoverParams (TextDocumentIdentifier uri) pos _workDone)
-        = req
-    result <- Handler.onHover uri pos
-    responder $ Right result
-  -- -- syntax highlighting
-  -- , requestHandler STextDocumentSemanticTokensFull $ \req responder -> do
-  --   result <- Handler.onHighlight (req ^. (params . textDocument . uri))
-  --   responder result
-  ]
+handlers =
+  mconcat
+    [ -- custom methods, not part of LSP
+      requestHandler (SCustomMethod "agda") $ \req responder -> do
+        let RequestMessage _ _i _ params = req
+        response <- Agda.sendCommand params
+        responder $ Right response,
+      -- hover provider
+      requestHandler STextDocumentHover $ \req responder -> do
+        let RequestMessage _ _ _ (HoverParams (TextDocumentIdentifier uri) pos _workDone) =
+              req
+        result <- Handler.onHover uri pos
+        responder $ Right result,
+      notificationHandler SInitialized $ \_not -> pure (),
+      notificationHandler STextDocumentDidOpen $ \_not -> pure ()
+      -- -- syntax highlighting
+      -- , requestHandler STextD_cumentSemanticTokensFull $ \req responder -> do
+      --   result <- Handler.onHighlight (req ^. (params . textDocument . uri))
+      --   responder result
+    ]

--- a/src/Server.hs
+++ b/src/Server.hs
@@ -112,7 +112,8 @@ handlers =
       notificationHandler SInitialized $ \_not -> pure (),
       notificationHandler STextDocumentDidOpen $ \_not -> pure (),
       notificationHandler STextDocumentDidSave $ \_not -> pure (),
-      notificationHandler STextDocumentDidChange $ \_not -> pure ()
+      notificationHandler STextDocumentDidChange $ \_not -> pure (),
+      notificationHandler SCancelRequest $ \_not -> pure ()
       -- -- syntax highlighting
       -- , requestHandler STextD_cumentSemanticTokensFull $ \req responder -> do
       --   result <- Handler.onHighlight (req ^. (params . textDocument . uri))

--- a/src/Server/Handler.hs
+++ b/src/Server/Handler.hs
@@ -40,7 +40,11 @@ import           Agda.TypeChecking.Monad        ( HasOptions(commandLineOptions)
                                                 , setInteractionOutputCallback
                                                 )
 import           Agda.TypeChecking.Warnings     ( runPM )
+#if MIN_VERSION_Agda(2,6,4)
+import           Agda.Syntax.Common.Pretty      ( render )
+#else
 import           Agda.Utils.Pretty              ( render )
+#endif
 import           Control.Concurrent.STM
 import           Control.Monad.Reader
 import           Control.Monad.State

--- a/stack-9.2-Agda-2.6.3.yaml
+++ b/stack-9.2-Agda-2.6.3.yaml
@@ -7,9 +7,11 @@ packages:
 - .
 
 extra-deps:
-- Agda-2.6.4
+- Agda-2.6.3
 
 flags:
+  agda-language-server:
+    Agda-2-6-3: true
   Agda:
     # optimise-heavily: true
     enable-cluster-counting: true

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: Agda-2.6.3@sha256:a668ab56534bd548c682088f595939a6b8732b46b84d7e7d808af966b5d5d4ec,36760
+    hackage: Agda-2.6.4@sha256:298bc3b261ad034bf4ee788834a4d296aa5c2f6ea17ac4bef44e3daea53a7cd8,28443
     pantry-tree:
-      sha256: 3c60f373128b663640a90fbc6fcffcb9a5edd57e8dfc4a7b00d2f7771f9210ac
-      size: 41559
+      sha256: 6c811b2ff8aa666ba301666e87d9234993d841dd370d47f8398379cd943e47bb
+      size: 42645
   original:
-    hackage: Agda-2.6.3
+    hackage: Agda-2.6.4
 snapshots:
 - completed:
     sha256: 5a59b2a405b3aba3c00188453be172b85893cab8ebc352b1ef58b0eae5d248a2


### PR DESCRIPTION
- From Agda 2.6.3 use `Agda.TypeChecking.Error.explainWhyInScope`
- Use `showInfoError` from `EmacsTop` rather than duplicating it here
- v0.2.6.4.0: Build with and embed Agda-2.6.4
