### PR TITLE
Add an option to run Agda setup if compiled with Agda v2.8.0 or later

### DIFF
--- a/src/Options.hs
+++ b/src/Options.hs
@@ -39,13 +39,14 @@ usageMessage = usageInfo usage options ++ usageAboutAgdaOptions
 data Options = Options
   { optViaTCP :: Maybe Int,
     optRawAgdaOptions :: [String],
+    optSetup :: Bool,
     optHelp :: Bool,
     optVersion :: Bool
   }
 
 defaultOptions :: Options
 defaultOptions =
-  Options {optViaTCP = Nothing, optRawAgdaOptions = [], optHelp = False, optVersion = False}
+  Options {optViaTCP = Nothing, optRawAgdaOptions = [], optSetup = False, optHelp = False, optVersion = False}
 
 options :: [OptDescr (Options -> Options)]
 options =
@@ -65,6 +66,13 @@ options =
           "PORT"
       )
       "talk with the editor via TCP port (4096 as default)",
+#if MIN_VERSION_Agda(2,8,0)
+    Option
+      []
+      ["setup"]
+      (NoArg (\opts -> opts {optSetup = True}))
+      "run Agda setup and exit",
+#endif
     Option
       ['V']
       ["version"]


### PR DESCRIPTION
Enable ALS to extract data files into the specified data dir with the command `als --setup` if [this feature](https://agda.readthedocs.io/en/v2.8.0/tools/command-line-options.html#cmdoption-setup) is available (added in Agda v2.8.0). This makes it easier to use the WebAssembly build to be able to utilize the bundled data files.