### PR TITLE
Add als executable as dependency of test-suite

### DIFF
--- a/agda-language-server.cabal
+++ b/agda-language-server.cabal
@@ -1,6 +1,6 @@
-cabal-version: 1.12
+cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.3.
 --
 -- see: https://github.com/sol/hpack
 
@@ -72,8 +72,6 @@ library
       Server.Handler
       Server.ResponseController
       Switchboard
-  other-modules:
-      Paths_agda_language_server
   hs-source-dirs:
       src
   default-extensions:
@@ -118,8 +116,6 @@ library
 
 executable als
   main-is: Main.hs
-  other-modules:
-      Paths_agda_language_server
   hs-source-dirs:
       app
   default-extensions:
@@ -196,7 +192,6 @@ test-suite als-test
       Server.Handler
       Server.ResponseController
       Switchboard
-      Paths_agda_language_server
   hs-source-dirs:
       test
       src
@@ -206,6 +201,8 @@ test-suite als-test
       PatternSynonyms
       TypeOperators
   ghc-options: -Wincomplete-patterns -Wunused-do-bind -Wunused-foralls -Wwarnings-deprecations -Wwrong-do-bind -Wmissing-fields -Wmissing-methods -Wmissing-pattern-synonym-signatures -Wmissing-signatures -rtsopts -Werror=incomplete-patterns -fno-warn-orphans
+  build-tool-depends:
+      agda-language-server:als
   build-depends:
       Agda
     , aeson

--- a/package.yaml
+++ b/package.yaml
@@ -1,3 +1,14 @@
+verbatim:
+  # This makes hpack translate build-tools as build-tool-depends intstead of build-tools.
+  # The latter causes problems with cabal2Nix, which otherwise misinterprets
+  # the dependency on the als executable added to the test suite via build-tools as an
+  # external dependency which will be missing.
+  #
+  # For hpack to use build-tool-depends cabal-version must be >= 2.
+  # Also hpack needs to be at least 0.38.0
+  cabal-version: 2.0
+spec-version: 0.38.0
+
 name:                agda-language-server
 version:             0.2.7.0.1.5
 github:              "banacorn/agda-language-server"
@@ -128,6 +139,11 @@ tests:
     source-dirs:
       - test
       - src
+    # While stack test automatically adds the als executable to PATH, so that it
+    # can be found by the test suite, cabal only does so if this is requested via
+    # build-tools / build-tool-depends.
+    build-tools:
+      - als
     dependencies:
       - lsp-test
       - tasty


### PR DESCRIPTION
I want to fix #33, so that this just works under nix, ideally without requiring any special treatment on the nix side. There are currently two problems stopping the package from building (without providing specific configuration):

- network-simple being pinned to 0.4.2
- The test suite not finding the als executable

This addresses the second one by making cabal add the als executable to PATH when running cabal test.

To be honest, I don't know how thiss interacts with other workflows, so I'm waiting to see if the GitHub Actions go through and for your comment. :)