### PR TITLE
Allow multiple +AGDA -AGDA blocks in cli arguments

### DIFF
--- a/src/Options.hs
+++ b/src/Options.hs
@@ -129,13 +129,20 @@ stripRTS (arg : argv)
     is x arg = [x] == take 1 (words arg)
 
 -- | Extract Agda options (+AGDA ... -AGDA) from a list of options
+--
+-- >>> extractAgdaOpts [ "als1", "+AGDA", "agda1", "-AGDA", "als2", "+AGDA", "agda2" ]
+-- (["als1","als2"],["agda1","agda2"])
 extractAgdaOpts :: [String] -> ([String], [String])
-extractAgdaOpts argv =
-  let (before, argv') = break (== "+AGDA") argv
-      (forAgda, after) = break (== "-AGDA") argv'
-      forALS = before ++ dropWhile (== "-AGDA") after
-      forAgda' = dropWhile (== "+AGDA") forAgda
-   in (forALS, forAgda')
+extractAgdaOpts argv = go False argv
+  where
+    go False ("+AGDA":xs) = go True xs
+    go True ("-AGDA":xs) = go False xs
+    go inagda (arg:xs) =
+      let (forALS, forAgda) = go inagda xs in
+      if inagda
+        then (forALS, arg:forAgda)
+        else (arg:forALS, forAgda)
+    go _ [] = ([], [])
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
I'm considering making a withPackages wrapper in nix, like there is for agda, which passes `+AGDA --library-file=/nix/store/... -AGDA` to als, but currently that would cause a subsequent `+AGDA` when calling the wrapper not to be recognised.